### PR TITLE
Correcting lists insert method

### DIFF
--- a/2__python_self_study_1/just_enough_python.md
+++ b/2__python_self_study_1/just_enough_python.md
@@ -279,8 +279,8 @@ letters = ['b', 'c']
 letters.append('d')
 print(letters) # ['b', 'c', 'd']
 
-# add an item to the beginning of the list
-letters.insert('a')
+# insert an item at a specific index in the list
+letters.insert(0,'a')
 print(letters) # ['a', 'b', 'c', 'd']
 
 # get the length of a list


### PR DESCRIPTION
## Correcting lists insert method

Corrected the lists insert method to explain that for the method to work we need to add the index as an argument.

### Before:
```python
letters = ['b', 'c', 'd']
letters.insert('a')  # Incorrect usage
# Error: TypeError: insert expected 2 arguments, got 1
```
### Now:
```python
letters = ['b', 'c', 'd']
letters.insert(0, 'a')  # Correct usage
print(letters)
# Output: ['a', 'b', 'c', 'd']
```